### PR TITLE
Support vuex module inheritance

### DIFF
--- a/src/vuex-annotations.spec.ts
+++ b/src/vuex-annotations.spec.ts
@@ -285,7 +285,7 @@ describe('Given a vuex module class with vuex-annotations', () => {
             });
 
         });
-        
+
         describe('When a parent\'s getter getter is gotten', () => {
 
             let token: string | undefined = undefined;
@@ -316,7 +316,7 @@ describe('Given a vuex module class with vuex-annotations', () => {
                 expect(childModule!.getToken()).toBe('childchild' + payload);
             });
         });
-        
+
         describe('When a parent\'s mutation is called with a payload', () => {
 
             const payload: string = 'newToken';
@@ -351,7 +351,7 @@ describe('Given a vuex module class with vuex-annotations', () => {
             });
 
         });
-        
+
         describe('When a parent\'s action is called with a payload', () => {
 
             const payload: string = 'token';

--- a/src/vuex-annotations.spec.ts
+++ b/src/vuex-annotations.spec.ts
@@ -4,76 +4,84 @@ import Vue from 'vue';
 
 Vue.use(Vuex);
 
+const INITIAL_TOKEN_IN_PARENT: string = 'initialTokenInParent';
+const INITIAL_PARENT_TOKEN_IN_PARENT: string = 'initialParentTokenInParent';
+const INITIAL_TOKEN_IN_CHILD: string = 'initialTokenInChild';
+
+const PARENT_PREFIX: string = 'parent';
+const CHILD_PREFIX: string = 'child';
+const SPECIAL_PREFIX: string = 'special';
+
 class ParentModuleState {
-    public token = 'initialParentToken';
-    public parentToken = 'initialParentToken';
+    public token = INITIAL_TOKEN_IN_PARENT;
+    public parentToken = INITIAL_PARENT_TOKEN_IN_PARENT;
 }
 
 class ChildModuleState extends ParentModuleState {
-    public token = 'initialChildToken';
+    public token = INITIAL_TOKEN_IN_CHILD;
 }
 
 class ParentModule<S extends ParentModuleState> extends ModuleBase<S> {
     @Getter()
     getToken(): string {
-        return this.state.token;
+        return PARENT_PREFIX + this.state.token;
     }
 
     @Getter()
     get token(): string {
-        return this.state.token;
+        return PARENT_PREFIX + this.state.token;
     }
 
     @Mutation()
     setToken(token: string): void {
-        this.state.token = token;
+        this.state.token = PARENT_PREFIX + token;
     }
 
     @Action()
     setSpecialToken(token: string): void {
-        this.setToken('special' + token);
+        this.setToken(SPECIAL_PREFIX + token);
     }
 
     @Getter()
     getParentToken(): string {
-        return this.state.parentToken;
+        return PARENT_PREFIX + this.state.parentToken;
     }
 
     @Getter()
     get parentToken(): string {
-        return this.state.parentToken;
+        return PARENT_PREFIX + this.state.parentToken;
     }
 
     @Mutation()
     setParentToken(parentToken: string): void {
-        this.state.parentToken = parentToken;
+        this.state.parentToken = PARENT_PREFIX + parentToken;
     }
 
     @Action()
     setSpecialParentToken(parentToken: string): void {
-        this.setParentToken('special' + parentToken);
+        this.setParentToken(SPECIAL_PREFIX + parentToken);
     }
 }
 
 class ChildModule extends ParentModule<ChildModuleState> {
     @Getter()
     getToken(): string {
-        return 'child' + this.state.token;
+        return CHILD_PREFIX + this.state.token;
     }
 
     @Getter()
     get token(): string {
-        return 'child' + this.state.token;
+        return CHILD_PREFIX + this.state.token;
     }
 
     @Mutation()
     setToken(token: string): void {
-        this.state.token = 'child' + token;
+        this.state.token = CHILD_PREFIX + token;
     }
 
     @Action()
     setSpecialToken(token: string): void {
-        this.setToken('specialChild' + token);
+        this.setToken(SPECIAL_PREFIX + token);
     }
 }
 
@@ -160,8 +168,8 @@ describe('Given a vuex module class with vuex-annotations', () => {
                 token = module!.getToken();
             });
 
-            test('Then, the token has the initialParentToken value', () => {
-                expect(token).toBe('initialParentToken');
+            test('Then, the token has the right value', () => {
+                expect(token).toBe(PARENT_PREFIX + INITIAL_TOKEN_IN_PARENT);
             });
 
         });
@@ -174,8 +182,8 @@ describe('Given a vuex module class with vuex-annotations', () => {
                 token = module!.token;
             });
 
-            test('Then, the token has the initialParentToken value', () => {
-                expect(token).toBe('initialParentToken');
+            test('Then, the token has the right value', () => {
+                expect(token).toBe(PARENT_PREFIX + INITIAL_TOKEN_IN_PARENT);
             });
 
         });
@@ -193,7 +201,7 @@ describe('Given a vuex module class with vuex-annotations', () => {
             });
 
             test('Then, the state token has been changed correctly', () => {
-                expect(module!.getToken()).toBe(payload);
+                expect(module!.getToken()).toBe(PARENT_PREFIX + PARENT_PREFIX + payload);
             });
         });
 
@@ -210,7 +218,7 @@ describe('Given a vuex module class with vuex-annotations', () => {
             });
 
             test('Then, the state token has been changed correctly', () => {
-                expect(module!.getToken()).toBe('special' + payload);
+                expect(module!.getToken()).toBe(PARENT_PREFIX + PARENT_PREFIX + SPECIAL_PREFIX + payload);
             });
 
         });
@@ -252,8 +260,8 @@ describe('Given a vuex module class with vuex-annotations', () => {
                 token = childModule!.getToken();
             });
 
-            test('Then, the token has the childinitialChildToken value', () => {
-                expect(token).toBe('childinitialChildToken');
+            test('Then, the token has the right value', () => {
+                expect(token).toBe(CHILD_PREFIX + INITIAL_TOKEN_IN_CHILD);
             });
 
         });
@@ -266,8 +274,8 @@ describe('Given a vuex module class with vuex-annotations', () => {
                 token = childModule!.getParentToken();
             });
 
-            test('Then, the token has the initialParentToken value', () => {
-                expect(token).toBe('initialParentToken');
+            test('Then, the token has the right value', () => {
+                expect(token).toBe(PARENT_PREFIX + INITIAL_PARENT_TOKEN_IN_PARENT);
             });
 
         });
@@ -280,8 +288,8 @@ describe('Given a vuex module class with vuex-annotations', () => {
                 token = childModule!.token;
             });
 
-            test('Then, the token has the childinitialChildToken value', () => {
-                expect(token).toBe('childinitialChildToken');
+            test('Then, the token has the right value', () => {
+                expect(token).toBe(CHILD_PREFIX + INITIAL_TOKEN_IN_CHILD);
             });
 
         });
@@ -294,8 +302,8 @@ describe('Given a vuex module class with vuex-annotations', () => {
                 token = childModule!.parentToken;
             });
 
-            test('Then, the token has the initialParentToken value', () => {
-                expect(token).toBe('initialParentToken');
+            test('Then, the token has the right value', () => {
+                expect(token).toBe(PARENT_PREFIX + INITIAL_PARENT_TOKEN_IN_PARENT);
             });
 
         });
@@ -330,7 +338,7 @@ describe('Given a vuex module class with vuex-annotations', () => {
             });
 
             test('Then, the state token has been changed correctly', () => {
-                expect(childModule!.getParentToken()).toBe(payload);
+                expect(childModule!.getParentToken()).toBe(PARENT_PREFIX + PARENT_PREFIX + payload);
             });
         });
 
@@ -347,7 +355,7 @@ describe('Given a vuex module class with vuex-annotations', () => {
             });
 
             test('Then, the state token has been changed correctly', () => {
-                expect(childModule!.getToken()).toBe('childchildspecialChild' + payload);
+                expect(childModule!.getToken()).toBe(CHILD_PREFIX + CHILD_PREFIX + SPECIAL_PREFIX + payload);
             });
 
         });
@@ -365,7 +373,7 @@ describe('Given a vuex module class with vuex-annotations', () => {
             });
 
             test('Then, the state token has been changed correctly', () => {
-                expect(childModule!.getParentToken()).toBe('special' + payload);
+                expect(childModule!.getParentToken()).toBe(PARENT_PREFIX + PARENT_PREFIX + SPECIAL_PREFIX + payload);
             });
 
         });

--- a/src/vuex-annotations.ts
+++ b/src/vuex-annotations.ts
@@ -56,7 +56,7 @@ export function Getter(): GetterFunc {
             target['_getters'] = {};
         }
 
-        if(target['_getters'][key]) {
+        if (target['_getters'][key]) {
             throw new Error('Duplicate getter key ' + key + ' of target ' + target.constructor.name + ' has already been set');
         }
 
@@ -88,7 +88,7 @@ export function Mutation(params?: { options: Vuex.CommitOptions }): MutationFunc
             target['_mutations'] = {};
         }
 
-        if(target['_mutations'][key]) {
+        if (target['_mutations'][key]) {
             throw new Error('Duplicate mutation key ' + key + ' of target ' + target.constructor.name + ' has already been set');
         }
 
@@ -120,7 +120,7 @@ export function Action(): ActionFunc {
             target['_actions'] = {};
         }
 
-        if(target['_actions'][key]) {
+        if (target['_actions'][key]) {
             throw new Error('Duplicate action key ' + key + ' of target ' + target.constructor.name + ' has already been set');
         }
 
@@ -142,12 +142,12 @@ function bindThis(_this: any, object: any): any {
 
 function getRecursiveAnnotations(object: any, keyAnnotations: string): any {
     const recursiveAnnotations: any = {};
-    
+
     let parentObject: any = Object.getPrototypeOf(object);
-    
-    while(parentObject) {
-        for(var key in parentObject[keyAnnotations]) {
-            if(!recursiveAnnotations[key]) {
+
+    while (parentObject) {
+        for (let key in parentObject[keyAnnotations]) {
+            if (!recursiveAnnotations[key]) {
                 recursiveAnnotations[key] = parentObject[keyAnnotations][key];
             }
         }

--- a/src/vuex-annotations.ts
+++ b/src/vuex-annotations.ts
@@ -52,9 +52,14 @@ export function Getter(): GetterFunc {
         hasArguments ? descriptor.value = getterFunction : descriptor.get = getterFunction;
 
         // Keep a copy of the wrapped function so that it can be registered
-        if (!target['_getters']) {
+        if (!Object.getOwnPropertyDescriptor(target, '_getters')) {
             target['_getters'] = {};
         }
+
+        if(target['_getters'][key]) {
+            throw new Error('Duplicate getter key ' + key + ' of target ' + target.constructor.name + ' has already been set');
+        }
+
         target['_getters'][key] = wrapperFunction;
     };
 }
@@ -79,9 +84,14 @@ export function Mutation(params?: { options: Vuex.CommitOptions }): MutationFunc
 
         descriptor.value = commitFunction;
 
-        if (!target['_mutations']) {
+        if (!Object.getOwnPropertyDescriptor(target, '_mutations')) {
             target['_mutations'] = {};
         }
+
+        if(target['_mutations'][key]) {
+            throw new Error('Duplicate mutation key ' + key + ' of target ' + target.constructor.name + ' has already been set');
+        }
+
         target['_mutations'][key] = wrapperFunction;
     };
 }
@@ -106,9 +116,14 @@ export function Action(): ActionFunc {
 
         descriptor.value = dispatchFunction;
 
-        if (!target['_actions']) {
+        if (!Object.getOwnPropertyDescriptor(target, '_actions')) {
             target['_actions'] = {};
         }
+
+        if(target['_actions'][key]) {
+            throw new Error('Duplicate action key ' + key + ' of target ' + target.constructor.name + ' has already been set');
+        }
+
         target['_actions'][key] = wrapperFunction;
     };
 }
@@ -125,6 +140,24 @@ function bindThis(_this: any, object: any): any {
     return binded;
 }
 
+function getRecursiveAnnotations(object: any, keyAnnotations: string): any {
+    const recursiveAnnotations: any = {};
+    
+    let parentObject: any = Object.getPrototypeOf(object);
+    
+    while(parentObject) {
+        for(var key in parentObject[keyAnnotations]) {
+            if(!recursiveAnnotations[key]) {
+                recursiveAnnotations[key] = parentObject[keyAnnotations][key];
+            }
+        }
+
+        parentObject = Object.getPrototypeOf(parentObject);
+    }
+
+    return recursiveAnnotations;
+}
+
 /**
  * This class is the required base class to be able to use the Getter, Mutation, and Action decorators.
  *
@@ -138,9 +171,9 @@ export abstract class ModuleBase<S> {
         const options: Vuex.Module<S, {}> = {
             namespaced: true,
             state,
-            getters: bindThis(this, (this as any)['_getters']),
-            actions: bindThis(this, (this as any)['_actions']),
-            mutations: bindThis(this, (this as any)['_mutations'])
+            getters: bindThis(this, getRecursiveAnnotations(this, '_getters')),
+            actions: bindThis(this, getRecursiveAnnotations(this, '_actions')),
+            mutations: bindThis(this, getRecursiveAnnotations(this, '_mutations'))
         };
 
         store.registerModule(this.moduleName, options);


### PR DESCRIPTION
Adding support for vuex module inheritance.

* Supports class members overriding
* Supports class members inheritance from parent classes

Example

```ts
class ParentModuleState {}

class ChildModuleState extends ParentModuleState {}

class ParentModule<S extends ParentModuleState> extends ModuleBase<S> {}

class ChildModule extends ParentModule<ChildModuleState> {}

```